### PR TITLE
docs: update README with v0.4 status and competitor comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Four roles coordinate the work:
 - **Contracts before code** — architect defines interfaces between experts before work starts
 - **Knowledge has a lifecycle** — learnings graduate from logs to state to identity
 - **Pools + shared experts** — project-scoped pools with reusable cross-project specialists
-- **Zero-dependency message bus** — filesystem + fsnotify, no databases or queues
+- **Zero-infrastructure message bus** — filesystem + fsnotify, no databases or queues
 - **Daemon-managed scheduling** — bookkeeping in Go, not in the LLM
 
 ## Quick Start
@@ -77,11 +77,13 @@ Agent Pool draws inspiration from two prominent multi-agent frameworks — [Gas 
 
 ### Design Lineage
 
-**From Gas Town:** GUPP, handoff mechanics, log recall, formulas, named roles.
+**From [Gas Town](https://github.com/steveyegge/gastown):** GUPP, handoff mechanics, log recall, formulas, named roles.
 Left behind: scale ambition, Dolt data plane, multi-provider support.
 
-**From OpenClaw:** Workspace-as-brain, self-improvement patterns, promotion ladder, compaction flush, identity split.
+**From [OpenClaw](https://github.com/openclaw/openclaw):** Workspace-as-brain, self-improvement patterns, promotion ladder, compaction flush, identity split.
 Left behind: always-on Gateway, plugin ecosystem, multi-LLM support, multi-channel messaging.
+
+See [architecture doc § Design Lineage](docs/plans/architecture.md#design-lineage) for full provenance and references.
 
 ### Agent Pool's Niche
 


### PR DESCRIPTION
## Summary
- Update development status from v0.1 to full v0.1–v0.8 roadmap table (v0.3 complete, v0.4 in progress)
- Add "How Agent Pool Compares" section with Gas Town and OpenClaw feature comparison tables
- Add positioning paragraph explaining Agent Pool's niche (depth vs scale vs reach)

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm comparison facts against architecture doc Design Lineage section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added two Key Properties clarifying a filesystem+fsnotify message bus and daemon-managed scheduling/bookkeeping.
  * Added a "How Agent Pool Compares" section with narrative, comparison table, design lineage, and an "Agent Pool’s Niche" paragraph.
  * Replaced a status line with a new Development section listing consolidated make commands.
  * Added a versioned Development Status table (v0.1–v0.8) with per-version statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->